### PR TITLE
fix CI failure with Python versions not being available for some reason

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -271,6 +271,7 @@ jobs:
         with:
           python-version: |
             ${{ matrix.python-version }}
+            3.11
 
       - name: System Python Information
         uses: twisted/python-info-action@v1


### PR DESCRIPTION
not sure why this broke?