### PR TITLE
add a schema builder

### DIFF
--- a/src/dbxs/schema.py
+++ b/src/dbxs/schema.py
@@ -1,0 +1,91 @@
+# -*- test-case-name: dbxs.test.test_schema -*-
+"""
+Schema-building utilities.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from threading import local
+from typing import Callable, TypeVar
+
+
+__all__ = [
+    "SchemaBuilder",
+]
+
+T = TypeVar("T")
+
+
+_tableSchema = """\
+CREATE TABLE IF NOT EXISTS {tableName} (
+    {columns}
+);
+"""
+
+
+@dataclass
+class _WorkingTable:
+    back: _WorkingTable | None
+    columns: list[str] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+
+
+class _TableStack(local):
+    current: _WorkingTable | None = None
+
+    def push(self) -> _WorkingTable:
+        current = self.current = _WorkingTable(self.current)
+        return current
+
+    def get(self) -> _WorkingTable:
+        if self.current is None:
+            raise RuntimeError("not currently defining a table")
+        return self.current
+
+    def pop(self) -> _WorkingTable:
+        self.current = (result := self.get()).back
+        return result
+
+
+@dataclass
+class SchemaBuilder:
+    """
+    A L{SchemaBuilder} can associate fragments of a schema in-line with
+    classes.
+    """
+
+    schema: str = ""
+    _stack: _TableStack = field(default_factory=_TableStack)
+
+    def table(self, tableName: str) -> Callable[[T], T]:
+        """
+        Decorate a class with this method to create a new table.
+        """
+        work = self._stack.push()
+
+        def buildSchema(c: T) -> T:
+            assert self._stack.pop() is work, "stack should match"
+            sep = ",\n    "
+            sep.join(work.columns)
+            partialSchema = _tableSchema.format(
+                tableName=tableName,
+                columns=sep.join(work.columns + work.constraints),
+            )
+            self.schema += partialSchema
+            return c
+
+        return buildSchema
+
+    def column(self, columnText: str) -> None:
+        """
+        Create a new column within a class decorated by L{SchemaBuilder.table}.
+        """
+        self._stack.get().columns.append(columnText)
+
+    def constraint(self, constraintText: str) -> None:
+        """
+        Create a new standalone constraint within a class decorated by
+        L{SchemaBuilder.table}.
+        """
+        self._stack.get().constraints.append(constraintText)

--- a/src/dbxs/schema.py
+++ b/src/dbxs/schema.py
@@ -24,6 +24,12 @@ CREATE TABLE IF NOT EXISTS {tableName} (
 """
 
 
+class NotCurrentlyDefining(RuntimeError):
+    """
+    A L{SchemaBuilder} method was called while not defining a table.
+    """
+
+
 @dataclass
 class _WorkingTable:
     back: _WorkingTable | None
@@ -40,7 +46,7 @@ class _TableStack(local):
 
     def get(self) -> _WorkingTable:
         if self.current is None:
-            raise RuntimeError("not currently defining a table")
+            raise NotCurrentlyDefining("not currently defining a table")
         return self.current
 
     def pop(self) -> _WorkingTable:

--- a/src/dbxs/test/test_schema.py
+++ b/src/dbxs/test/test_schema.py
@@ -1,0 +1,80 @@
+"""
+Tests for L{dbxs.schema}.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from textwrap import dedent
+from unittest import TestCase
+
+from dbxs.schema import SchemaBuilder
+
+
+class SchemaBuilderTests(TestCase):
+    def test_simpleSchema(self) -> None:
+        """
+        Decorating a class with L{SchemaBuilder.table} and then calling
+        L{SchemaBuilder.column} on it from within the class body will generate
+        a C{CREATE TABLE IF NOT EXISTS} statement in the schema.
+        """
+        builder = SchemaBuilder()
+
+        @builder.table("hello")
+        @dataclass
+        class Hello:
+            foo: int
+            builder.column("foo INTEGER NOT NULL")
+            builder.constraint("UNIQUE (foo)")
+            bar: str
+            builder.column("bar TEXT NOT NULL")
+
+        self.assertEqual(
+            builder.schema,
+            dedent(
+                """\
+                CREATE TABLE IF NOT EXISTS hello (
+                    foo INTEGER NOT NULL,
+                    bar TEXT NOT NULL,
+                    UNIQUE (foo)
+                );
+                """
+            ),
+        )
+
+    def test_nesting(self) -> None:
+        """
+        Declaring a nested table-class with SchemaBuilder.table will emit the
+        inner table in the schema.
+        """
+        builder = SchemaBuilder()
+
+        @builder.table("hello")
+        @dataclass
+        class Hello:
+            foo: int
+            builder.column("foo INTEGER NOT NULL")
+
+            @builder.table("goodbye")
+            @dataclass
+            class Goodbye:
+                farewell: str
+                builder.column("farewell TEXT NOT NULL")
+
+            bar: str
+            builder.column("bar TEXT NOT NULL")
+
+        self.assertEqual(
+            builder.schema,
+            dedent(
+                """\
+                CREATE TABLE IF NOT EXISTS goodbye (
+                    farewell TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS hello (
+                    foo INTEGER NOT NULL,
+                    bar TEXT NOT NULL
+                );
+                """
+            ),
+        )

--- a/src/dbxs/test/test_schema.py
+++ b/src/dbxs/test/test_schema.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from unittest import TestCase
 
-from dbxs.schema import SchemaBuilder
+from dbxs.schema import NotCurrentlyDefining, SchemaBuilder
 
 
 class SchemaBuilderTests(TestCase):
@@ -78,3 +78,15 @@ class SchemaBuilderTests(TestCase):
                 """
             ),
         )
+
+    def test_errorHandling(self) -> None:
+        """
+        Using L{SchemaBuilder.column} outside of a class decorated with
+        C{@builder.table} will result in a comprehensible error.
+        """
+
+        builder = SchemaBuilder()
+        with self.assertRaises(NotCurrentlyDefining):
+            builder.column("something TEXT NOT NULL")
+        with self.assertRaises(NotCurrentlyDefining):
+            builder.constraint("foreign key, or whatever")


### PR DESCRIPTION
I am not sure what I am going to do with schema migrations, but it would be nice to have a way to intersperse the SQL for creating a table with class definitions