### PR TITLE
SQLAlchemy Core support

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -251,6 +251,12 @@ jobs:
             tox-suffix: "-mysql"
             mysql-image: "mysql:9"
             optional: false
+          - os: "ubuntu-latest"
+            python-version: "3.12"
+            twisted-version: "23.10"
+            tox-prefix: "coverage"
+            tox-suffix: "-sqlalchemy"
+            optional: false
 
     steps:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,4 +23,4 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "alabaster"
-html_static_path = ["_static"]
+html_static_path = []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,3 +24,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 html_theme = "alabaster"
 html_static_path = []
+
+# sqlalchemy.org is just entirely down right now, let's ignore it until it
+# comes back
+linkcheck_ignore = [r"https://docs.sqlalchemy.org/.*"]

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -1,5 +1,6 @@
 -r postgres.txt
+-r mysql.txt
+-r sqlalchemy.txt
 mypy==1.15.0
 mypy-zope==1.0.11
-mysql-connector-python==9.2.0
 types-click==7.1.8

--- a/requirements/sqlalchemy.txt
+++ b/requirements/sqlalchemy.txt
@@ -1,0 +1,1 @@
+SQLAlchemy==2.0.41

--- a/src/dbxs/_access.py
+++ b/src/dbxs/_access.py
@@ -34,7 +34,6 @@ from typing import (
 try:
     from sqlalchemy.engine.default import DefaultDialect
     from sqlalchemy.engine.interfaces import Dialect
-    from sqlalchemy.sql.compiler import SQLCompiler
     from sqlalchemy.sql.expression import Select
 except ImportError:
     pass
@@ -265,24 +264,6 @@ class MaybeAIterable:
 
 
 @dataclass
-class SQLAlchemyMapping:
-    compiled: SQLCompiler
-
-    @property
-    def names(self) -> list[str]:
-        return list(self.compiled.bind_names.values())
-
-    def __getitem__(self, __key: str) -> Any:
-        ...
-
-    def queryArguments(self, bound: BoundArguments) -> Sequence[object]:
-        # in sqlalchemy (or indeed for any named bind-param driver) this really
-        # wants to be returning a named dictionary rather than a
-        # sequence[object]
-        return [bound.arguments[each] for each in self.names]
-
-
-@dataclass
 class QueryMetadata(Generic[A]):
     """
     Metadata defining a certain function on a protocol as a query method.
@@ -324,9 +305,14 @@ class QueryMetadata(Generic[A]):
                         else DefaultDialect(strictStyle)
                     )
                 )
-                self.compilationCache[style] = str(compiled), (
-                    mapInstance := SQLAlchemyMapping(compiled)
+                positionTup = compiled.positiontup
+                mapInstance = (
+                    NamedParamstyleMap("", list(compiled.bind_names.values()))
+                    if positionTup is None
+                    else IndexCountingParamstyleMap("", positionTup)
                 )
+
+                self.compilationCache[style] = str(compiled), mapInstance
 
             selfExcluded = list(self.signature.parameters)[1:]
             if set(mapInstance.names) != set(selfExcluded):
@@ -480,7 +466,25 @@ class IndexCountingParamstyleMap:
 
 
 @dataclass
+class NumericParamstyleMap:
+    prefix: str
+    names: List[str] = field(default_factory=list)
+
+    def __getitem__(self, name: str) -> str:
+        if name not in self.names:
+            self.names.append(name)
+        return f"{self.prefix}{self.names.index(name) + 1}"
+
+    def queryArguments(self, bound: BoundArguments) -> Sequence[object]:
+        """
+        Compute the arguments to the query.
+        """
+        return [bound.arguments[each] for each in self.names]
+
+
+@dataclass
 class NamedParamstyleMap:
+    prefix: str
     names: list[str] = field(default_factory=list)
 
     def __getitem__(self, name: str) -> str:
@@ -517,8 +521,11 @@ class BinderMap(Protocol):
 
 styles: dict[str, Callable[[], BinderMap]] = {
     "qmark": lambda: IndexCountingParamstyleMap("?"),
+    "numeric": lambda: NumericParamstyleMap(":"),
+    "named": lambda: NamedParamstyleMap(":"),
+    "format": lambda: IndexCountingParamstyleMap("%s"),
     "pyformat": lambda: IndexCountingParamstyleMap("%s"),
-    "named": lambda: NamedParamstyleMap(),
+    "numeric_dollar": lambda: NumericParamstyleMap("$"),
 }
 
 

--- a/src/dbxs/_access.py
+++ b/src/dbxs/_access.py
@@ -267,7 +267,10 @@ class MaybeAIterable:
 @dataclass
 class SQLAlchemyMapping:
     compiled: SQLCompiler
-    names: List[str] = field(default_factory=list)
+
+    @property
+    def names(self) -> list[str]:
+        return list(self.compiled.bind_names.values())
 
     def __getitem__(self, __key: str) -> Any:
         ...
@@ -311,20 +314,19 @@ class QueryMetadata(Generic[A]):
             else:
                 # Right now all the precomputed SQL is generated at compile
                 # time.
+                strictStyle: StrictParamStyle = (
+                    style  # type:ignore[assignment]
+                )
                 compiled = self.sql.compile(
                     dialect=(
                         style
                         if isinstance(style, Dialect)
-                        else (
-                            DefaultDialect(style)
-                            if isinstance(style, StrictParamStyle)
-                            else None
-                        )
+                        else DefaultDialect(strictStyle)
                     )
                 )
-                self.compilationCache[style] = str(
-                    compiled
-                ), SQLAlchemyMapping(compiled)
+                self.compilationCache[style] = str(compiled), (
+                    mapInstance := SQLAlchemyMapping(compiled)
+                )
 
             selfExcluded = list(self.signature.parameters)[1:]
             if set(mapInstance.names) != set(selfExcluded):
@@ -500,7 +502,9 @@ PROTOCOL_IGNORED_ATTRIBUTES = set(_EmptyProtocol.__dict__.keys())
 
 
 class BinderMap(Protocol):
-    names: List[str]
+    @property
+    def names(self) -> Sequence[str]:
+        ...
 
     def __getitem__(self, __key: str) -> Any:
         ...

--- a/src/dbxs/_access.py
+++ b/src/dbxs/_access.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from inspect import (
     BoundArguments,
+    Signature,
     currentframe,
     getsourcefile,
     getsourcelines,
@@ -17,10 +18,10 @@ from typing import (
     Awaitable,
     Callable,
     Coroutine,
-    Dict,
     Generic,
     Iterable,
     List,
+    Mapping,
     NoReturn,
     Optional,
     Sequence,
@@ -29,8 +30,22 @@ from typing import (
     Union,
 )
 
+
+try:
+    from sqlalchemy.engine.default import DefaultDialect
+    from sqlalchemy.engine.interfaces import Dialect
+    from sqlalchemy.sql.compiler import SQLCompiler
+    from sqlalchemy.sql.expression import Select
+except ImportError:
+    pass
+
 from ._typing_compat import ParamSpec, Protocol
-from .async_dbapi import AsyncConnection, AsyncCursor
+from .async_dbapi import (
+    AsyncConnection,
+    AsyncCursor,
+    ParamStyle,
+    StrictParamStyle,
+)
 
 
 T = TypeVar("T")
@@ -182,7 +197,7 @@ def one(
 
 
 def maybe(
-    load: Callable[..., T]
+    load: Callable[..., T],
 ) -> Callable[[object, AsyncCursor], Coroutine[object, object, Optional[T]]]:
     """
     Fetch a single result and pass it to a translator function, but return None
@@ -197,7 +212,7 @@ def maybe(
 
 
 def many(
-    load: Callable[..., T]
+    load: Callable[..., T],
 ) -> Callable[[object, AsyncCursor], AsyncIterable[T]]:
     """
     Fetch multiple results with a function to translate rows.
@@ -250,38 +265,82 @@ class MaybeAIterable:
 
 
 @dataclass
+class SQLAlchemyMapping:
+    compiled: SQLCompiler
+    names: List[str] = field(default_factory=list)
+
+    def __getitem__(self, __key: str) -> Any:
+        ...
+
+    def queryArguments(self, bound: BoundArguments) -> Sequence[object]:
+        # in sqlalchemy (or indeed for any named bind-param driver) this really
+        # wants to be returning a named dictionary rather than a
+        # sequence[object]
+        return [bound.arguments[each] for each in self.names]
+
+
+@dataclass
 class QueryMetadata(Generic[A]):
     """
     Metadata defining a certain function on a protocol as a query method.
     """
 
-    sql: str
+    name: str
+    sql: str | Select
     load: Callable[[AccessProxy, AsyncCursor], A]
-    proxyMethod: Callable[..., Awaitable[object]] = field(init=False)
+    signature: Signature
+    compilationCache: dict[ParamStyle | Dialect, tuple[str, BinderMap]]
 
-    def setOn(self, protocolMethod: Any) -> None:
+    def computeSQLFor(
+        self, style: ParamStyle | Dialect
+    ) -> tuple[str, BinderMap]:
+        try:
+            return self.compilationCache[style]
+        except KeyError as ke:
+            if isinstance(self.sql, str):
+                mapFactory = styles[
+                    (
+                        style
+                        if isinstance(style, ParamStyle)
+                        else style.paramstyle
+                    )
+                ]
+                mapInstance = mapFactory()
+                styledSQL = self.sql.format_map(mapInstance)
+                self.compilationCache[style] = (styledSQL, mapInstance)
+            else:
+                # Right now all the precomputed SQL is generated at compile
+                # time.
+                compiled = self.sql.compile(
+                    dialect=(
+                        style
+                        if isinstance(style, Dialect)
+                        else (
+                            DefaultDialect(style)
+                            if isinstance(style, StrictParamStyle)
+                            else None
+                        )
+                    )
+                )
+                self.compilationCache[style] = str(
+                    compiled
+                ), SQLAlchemyMapping(compiled)
+
+            selfExcluded = list(self.signature.parameters)[1:]
+            if set(mapInstance.names) != set(selfExcluded):
+                raise ParamMismatch(
+                    f"when defining {self.name}(...), "
+                    f"SQL placeholders {mapInstance.names} != "
+                    f"function params {selfExcluded}"
+                ) from ke
+            return self.compilationCache[style]
+
+    def implement(self) -> Callable[..., Any]:
         """
-        Attach this QueryMetadata to the given protocol method definition,
-        checking its arguments and computing C{proxyMethod} in the process,
-        raising L{ParamMismatch} if the expected parameters do not match.
+        Construct an implementation of the method at runtime.
         """
-        sig = signature(protocolMethod)
-        precomputedSQL: Dict[str, Tuple[str, NameMapMapping]] = {}
-        for style, mapFactory in styles.items():
-            mapInstance = mapFactory()
-            styledSQL = self.sql.format_map(mapInstance)
-            precomputedSQL[style] = (styledSQL, mapInstance)
 
-        sampleSQL, sampleInstance = precomputedSQL["qmark"]
-        selfExcluded = list(sig.parameters)[1:]
-        if set(sampleInstance.names) != set(selfExcluded):
-            raise ParamMismatch(
-                f"when defining {protocolMethod.__name__}(...), "
-                f"SQL placeholders {sampleInstance.names} != "
-                f"function params {selfExcluded}"
-            )
-
-        def proxyMethod(
+        def implementationMethod(
             proxySelf: AccessProxy, *args: object, **kw: object
         ) -> Any:
             """
@@ -293,14 +352,13 @@ class QueryMetadata(Generic[A]):
                 the awaitable path, we should not need to do the runtime check
                 every time.
             """
-
             maybeai: MaybeAIterable
 
             async def body() -> Any:
                 conn = proxySelf.__query_connection__
-                styledSQL, styledMap = precomputedSQL[conn.paramstyle]
+                styledSQL, styledMap = self.computeSQLFor(conn.paramstyle)
                 cur = await conn.cursor()
-                bound = sig.bind(None, *args, **kw)
+                bound = self.signature.bind(None, *args, **kw)
                 bound.apply_defaults()
                 await cur.execute(styledSQL, styledMap.queryArguments(bound))
                 maybeAgen: Any = self.load(proxySelf, cur)
@@ -310,17 +368,33 @@ class QueryMetadata(Generic[A]):
                     await cur.close()
                     return result
                 else:
-                    # if it's aiterable, we should be iterating it, not
+                    # if it's aiterable, we should be aiterating it, not
                     # awaiting it.  MaybeAIterable takes care of the implicit
                     # await of _this_ coroutine.
-                    nonlocal maybeai
                     maybeai.cursor = cur
                     return maybeAgen
 
             maybeai = MaybeAIterable(body())
             return maybeai
 
-        self.proxyMethod = proxyMethod
+        return implementationMethod
+
+    @classmethod
+    def decorateMethod(
+        cls,
+        protocolMethod: Any,
+        sql: str | Select,
+        load: Callable[[AccessProxy, AsyncCursor], A],
+    ) -> None:
+        """
+        Attach a QueryMetadata to the given protocol method definition,
+        checking its arguments and computing C{proxyMethod} in the process,
+        raising L{ParamMismatch} if the expected parameters do not match.
+        """
+        sig = signature(protocolMethod)
+        self = cls(protocolMethod.__name__, sql, load, sig, {})
+        self.computeSQLFor("qmark")
+
         setattr(protocolMethod, METADATA_KEY, self)
 
     @classmethod
@@ -336,7 +410,13 @@ class QueryMetadata(Generic[A]):
         cls, protocolNamespace: Iterable[Tuple[str, object]]
     ) -> Iterable[Tuple[str, QueryMetadata]]:
         """
-        Load all QueryMetadata
+        Filter the namespace of a give L{Protocol} object to find all the
+        methods decorated with L{query} or L{statement}, and return the
+        L{QueryMetadata} objects corresponding to those decorations, paired
+        with their names.
+
+        @return: an iterable of 2-tuples of (name of method decorated with
+            L{query}, L{QueryMetadata} object describing that query).
         """
         extraneous = []
         for attrname, value in protocolNamespace:
@@ -354,16 +434,15 @@ class QueryMetadata(Generic[A]):
 
 def query(
     *,
-    sql: str,
+    sql: str | Select,
     load: Callable[[AccessProxy, AsyncCursor], A],
 ) -> Callable[[Callable[P, A]], Callable[P, A]]:
     """
-    Declare a query method.
+    Declare a query method (i.e. a DQL statement).
     """
-    qm = QueryMetadata(sql=sql, load=load)
 
     def decorator(f: Callable[P, A]) -> Callable[P, A]:
-        qm.setOn(f)
+        QueryMetadata.decorateMethod(f, sql, load)
         return f
 
     return decorator
@@ -371,25 +450,15 @@ def query(
 
 def statement(
     *,
-    sql: str,
+    sql: str | Select,
 ) -> Callable[
     [Callable[P, Coroutine[Any, Any, None]]],
     Callable[P, Coroutine[Any, Any, None]],
 ]:
     """
-    Declare a query method.
+    Declare a data-modification (DML) method.
     """
     return query(sql=sql, load=zero)
-
-
-@dataclass
-class DBProxy:
-    """
-    Database Proxy
-    """
-
-    name: str
-    transaction: AsyncConnection
 
 
 @dataclass
@@ -408,6 +477,18 @@ class IndexCountingParamstyleMap:
         return [bound.arguments[each] for each in self.names]
 
 
+@dataclass
+class NamedParamstyleMap:
+    names: list[str] = field(default_factory=list)
+
+    def __getitem__(self, name: str) -> str:
+        self.names.append(name)
+        return f":{name}"
+
+    def queryArguments(self, bound: BoundArguments) -> Mapping[str, object]:
+        return {each: bound.arguments[each] for each in self.names}
+
+
 class _EmptyProtocol(Protocol):
     """
     Empty protocol for setting a baseline of what attributes to ignore while
@@ -418,19 +499,22 @@ class _EmptyProtocol(Protocol):
 PROTOCOL_IGNORED_ATTRIBUTES = set(_EmptyProtocol.__dict__.keys())
 
 
-class NameMapMapping(Protocol):
+class BinderMap(Protocol):
     names: List[str]
 
     def __getitem__(self, __key: str) -> Any:
         ...
 
-    def queryArguments(self, bound: BoundArguments) -> Sequence[object]:
+    def queryArguments(
+        self, bound: BoundArguments
+    ) -> Sequence[object] | Mapping[str, object]:
         ...
 
 
-styles: dict[str, Callable[[], NameMapMapping]] = {
+styles: dict[str, Callable[[], BinderMap]] = {
     "qmark": lambda: IndexCountingParamstyleMap("?"),
     "pyformat": lambda: IndexCountingParamstyleMap("%s"),
+    "named": lambda: NamedParamstyleMap(),
 }
 
 
@@ -444,7 +528,8 @@ class AccessProxy:
 
 
 def accessor(
-    accessPatternProtocol: Callable[[], T]
+    accessPatternProtocol: Callable[[], T],
+    prevalidationStyle: ParamStyle | Dialect = "qmark",
 ) -> Callable[[AsyncConnection], T]:
     """
     Create a factory which binds a database transaction in the form of an
@@ -454,7 +539,7 @@ def accessor(
         f"_{accessPatternProtocol.__name__}_Accessor",
         tuple([AccessProxy]),
         {
-            name: metadata.proxyMethod
+            name: metadata.implement()
             for name, metadata in QueryMetadata.filterProtocolNamespace(
                 accessPatternProtocol.__dict__.items()
             )

--- a/src/dbxs/_testing.py
+++ b/src/dbxs/_testing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
-from typing import Any, Callable, Coroutine, List, TypeVar
+from typing import Any, Callable, Coroutine, List, Literal, TypeVar
 from unittest import TestCase
 from uuid import uuid4
 
@@ -27,12 +27,13 @@ def sqlite3Connector() -> Callable[[], DBAPIConnection]:
 
     held = None
 
-    def connect() -> DBAPIConnection:
+    def connect(
+        *,
         # This callable has to hang on to a connection to the underlying SQLite
         # data structures, otherwise its schema and shared cache disappear as
-        # soon as it's garbage collected.  This 'nonlocal' stateemnt adds it to
-        # the closure, which keeps the reference after it's created.
-        nonlocal held
+        # soon as it's garbage collected.
+        held: object = held,
+    ) -> DBAPIConnection:
         return sqlite3.connect(uri, uri=True)
 
     held = connect()
@@ -88,7 +89,10 @@ class MemoryPool:
         return steps
 
     @classmethod
-    def new(cls) -> MemoryPool:
+    def new(
+        cls,
+        style: Literal["named"] | Literal["qmark"] = "qmark",
+    ) -> MemoryPool:
         """
         Create a synchronous memory connection pool.
         """
@@ -105,7 +109,7 @@ class MemoryPool:
         return MemoryPool(
             adaptSynchronousDriver(
                 sqlite3Connector(),
-                sqlite3.paramstyle,
+                style,
                 createWorker=createWorker,
                 callFromThread=lambda f: f(),
                 maxIdleConnections=10,
@@ -184,12 +188,16 @@ def immediateTest(
 
     def decorator(decorated: syncAsyncTest[AnyTestCase]) -> regularTest:
         def regular(self: AnyTestCase) -> None:
-            pool = MemoryPool.new()
-            d = driver.schedule(self.fail, decorated(self, pool))
-            d.assertNoResult()
-            while pool.flush():
-                pass
-            d.assertSuccessResult()
+            def body(style: Literal["qmark"] | Literal["named"]) -> None:
+                pool = MemoryPool.new(style=style)
+                d = driver.schedule(self.fail, decorated(self, pool))
+                d.assertNoResult()
+                while pool.flush():
+                    pass
+                d.assertSuccessResult()
+
+            body("qmark")
+            body("named")
 
         return regular
 

--- a/src/dbxs/_testing.py
+++ b/src/dbxs/_testing.py
@@ -25,15 +25,11 @@ def sqlite3Connector() -> Callable[[], DBAPIConnection]:
     """
     uri = f"file:{str(uuid4())}?mode=memory&cache=shared"
 
-    held = None
-
-    def connect(
-        *,
+    def connect() -> DBAPIConnection:
         # This callable has to hang on to a connection to the underlying SQLite
         # data structures, otherwise its schema and shared cache disappear as
         # soon as it's garbage collected.
-        held: object = held,
-    ) -> DBAPIConnection:
+        held
         return sqlite3.connect(uri, uri=True)
 
     held = connect()

--- a/src/dbxs/_testing.py
+++ b/src/dbxs/_testing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
-from typing import Any, Callable, Coroutine, List, Literal, TypeVar
+from typing import Any, Callable, Coroutine, List, Literal, Sequence, TypeVar
 from unittest import TestCase
 from uuid import uuid4
 
@@ -89,7 +89,9 @@ class MemoryPool:
     @classmethod
     def new(
         cls,
-        style: Literal["named"] | Literal["qmark"] = "qmark",
+        style: (
+            Literal["named"] | Literal["qmark"] | Literal["numeric_dollar"]
+        ) = "qmark",
     ) -> MemoryPool:
         """
         Create a synchronous memory connection pool.
@@ -177,8 +179,12 @@ class ImmediateDeferred:
         return DeferredCompletionTester(failer, succeeded, failed)
 
 
+SQLiteStyle = Literal["qmark"] | Literal["named"] | Literal["numeric_dollar"]
+
+
 def immediateTest(
     driver: ImmediateDriver = ImmediateDeferred,
+    styles: Sequence[SQLiteStyle] = ("qmark",),
 ) -> Callable[[syncAsyncTest[AnyTestCase]], regularTest[AnyTestCase]]:
     """
     Decorate an C{async def} test that expects a coroutine.
@@ -186,7 +192,9 @@ def immediateTest(
 
     def decorator(decorated: syncAsyncTest[AnyTestCase]) -> regularTest:
         def regular(self: AnyTestCase) -> None:
-            def body(style: Literal["qmark"] | Literal["named"]) -> None:
+            def body(
+                style: SQLiteStyle,
+            ) -> None:
                 pool = MemoryPool.new(style=style)
                 d = driver.schedule(self.fail, decorated(self, pool))
                 d.assertNoResult()
@@ -194,8 +202,14 @@ def immediateTest(
                     pass
                 d.assertSuccessResult()
 
-            body("qmark")
-            body("named")
+            # this slightly odd style is meant to encode which style fails in
+            # the traceback
+            if "qmark" in styles:
+                body("qmark")
+            if "named" in styles:
+                body("named")
+            if "numeric_dollar" in styles:
+                body("numeric_dollar")
 
         return regular
 

--- a/src/dbxs/_testing.py
+++ b/src/dbxs/_testing.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
-from typing import Any, Callable, Coroutine, List, Literal, Sequence, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    List,
+    Literal,
+    Sequence,
+    TypeVar,
+)
 from unittest import TestCase
 from uuid import uuid4
 
@@ -16,6 +25,12 @@ from ._typing_compat import Protocol
 from .adapters.dbapi_twisted import adaptSynchronousDriver
 from .async_dbapi import AsyncConnectable
 from .dbapi import DBAPIConnection
+
+
+if TYPE_CHECKING:
+    SQLiteStyle = (
+        Literal["qmark"] | Literal["named"] | Literal["numeric_dollar"]
+    )
 
 
 def sqlite3Connector() -> Callable[[], DBAPIConnection]:
@@ -177,9 +192,6 @@ class ImmediateDeferred:
         deferred = Deferred.fromCoroutine(coroutine)
         deferred.addCallbacks(succeeded.append, failed.append)
         return DeferredCompletionTester(failer, succeeded, failed)
-
-
-SQLiteStyle = Literal["qmark"] | Literal["named"] | Literal["numeric_dollar"]
 
 
 def immediateTest(

--- a/src/dbxs/_testing.py
+++ b/src/dbxs/_testing.py
@@ -25,6 +25,8 @@ def sqlite3Connector() -> Callable[[], DBAPIConnection]:
     """
     uri = f"file:{str(uuid4())}?mode=memory&cache=shared"
 
+    held: list[DBAPIConnection] = []
+
     def connect() -> DBAPIConnection:
         # This callable has to hang on to a connection to the underlying SQLite
         # data structures, otherwise its schema and shared cache disappear as
@@ -32,7 +34,7 @@ def sqlite3Connector() -> Callable[[], DBAPIConnection]:
         held
         return sqlite3.connect(uri, uri=True)
 
-    held = connect()
+    held.append(connect())
     return connect
 
 

--- a/src/dbxs/_typing_compat.py
+++ b/src/dbxs/_typing_compat.py
@@ -3,6 +3,7 @@ Since we support a range of Python and Mypy versions where certain features are
 available across L{typing} and L{typing_extensions}, we put those aliases here
 to avoid repeating conditional import logic.
 """
+
 import sys
 
 

--- a/src/dbxs/adapters/async_mysql.py
+++ b/src/dbxs/adapters/async_mysql.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Optional, Sequence, Union
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 
 from mysql.connector import paramstyle as mysqlParamStyle
 from mysql.connector.aio.abstracts import (
@@ -52,9 +52,13 @@ class _MYSQL2DBXSCursor:
     async def execute(
         self,
         operation: str,
-        parameters: Union[Sequence[Any], dict[str, Any]] = (),
+        parameters: Union[Sequence[Any], Mapping[str, Any]] = (),
     ) -> object:
-        await self._mysqlcur.execute(operation, parameters)
+        await self._mysqlcur.execute(
+            operation,
+            # mysql only supports dict() but let's not be too picky
+            parameters,  # type:ignore[arg-type]
+        )
         return None
 
     # async def executemany(

--- a/src/dbxs/adapters/async_psycopg.py
+++ b/src/dbxs/adapters/async_psycopg.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Optional, Sequence, Union
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence, Union
 
 from psycopg import (
     AsyncConnection as PGAsyncConnection,
@@ -53,7 +53,7 @@ class _PG2DBXSCursor:
     async def execute(
         self,
         operation: str,
-        parameters: Union[Sequence[Any], dict[str, Any]] = (),
+        parameters: Union[Sequence[Any], Mapping[str, Any]] = (),
     ) -> object:
         return await self._pgcur.execute(operation, parameters)
 

--- a/src/dbxs/adapters/dbapi_twisted.py
+++ b/src/dbxs/adapters/dbapi_twisted.py
@@ -14,7 +14,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from queue import Queue
 from threading import Thread
-from typing import Any, Awaitable, Callable, Optional, Sequence, TypeVar
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Mapping,
+    Optional,
+    Sequence,
+    TypeVar,
+)
 
 from twisted._threads import AlreadyQuit, ThreadWorker
 from twisted._threads._ithreads import IExclusiveWorker
@@ -150,7 +158,7 @@ class ThreadedCursorAdapter(AsyncCursor):
     async def execute(
         self,
         operation: str,
-        parameters: Sequence[Any] | dict[str, Any] = (),
+        parameters: Sequence[Any] | Mapping[str, Any] = (),
     ) -> object:
         """
         Execute the given statement.

--- a/src/dbxs/async_dbapi.py
+++ b/src/dbxs/async_dbapi.py
@@ -35,7 +35,12 @@ ParamStyle = str
 # specify the ParamStyle type more precisely, like so:
 
 StrictParamStyle = Literal[
-    "qmark", "numeric", "named", "format", "pyformat", "numeric_dollar"
+    "qmark",
+    "numeric",
+    "named",
+    "format",
+    "pyformat",
+    "numeric_dollar",
 ]
 
 T = TypeVar("T")

--- a/src/dbxs/async_dbapi.py
+++ b/src/dbxs/async_dbapi.py
@@ -7,7 +7,16 @@ asynchronous.
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Optional, Sequence, TypeVar, Union
+from typing import (
+    Any,
+    AsyncIterator,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 from ._typing_compat import Protocol
 from .dbapi import DBAPIColumnDescription
@@ -25,7 +34,9 @@ ParamStyle = str
 # Sadly, db-api modules do not restrict themselves in this way, so we can't
 # specify the ParamStyle type more precisely, like so:
 
-# ParamStyle = Literal['qmark', 'numeric', 'named', 'format', 'pyformat']
+StrictParamStyle = Literal[
+    "qmark", "numeric", "named", "format", "pyformat", "numeric_dollar"
+]
 
 T = TypeVar("T")
 
@@ -57,7 +68,7 @@ class AsyncCursor(Protocol):
     async def execute(
         self,
         operation: str,
-        parameters: Union[Sequence[Any], dict[str, Any]] = (),
+        parameters: Union[Sequence[Any], Mapping[str, Any]] = (),
     ) -> object:
         ...
 

--- a/src/dbxs/test/test_access.py
+++ b/src/dbxs/test/test_access.py
@@ -23,6 +23,15 @@ from ..async_dbapi import AsyncConnection, transaction
 from ..testing import MemoryPool, immediateTest
 
 
+try:
+    from sqlalchemy.sql.expression import bindparam
+    from sqlalchemy.sql.schema import Column, MetaData, Table
+    from sqlalchemy.sql.sqltypes import Integer
+
+    alchemized = True
+except ImportError:
+    alchemized = False
+
 # Trying to stick to the public API for what we're testing; no underscores here.
 
 
@@ -54,10 +63,29 @@ class Oops2:  # point at this definition(many)
     extra: str
 
 
+if alchemized:
+    alchemyMetadata = MetaData()
+    fooTable = Table(
+        "foo",
+        alchemyMetadata,
+        Column("bar", Integer, primary_key=True, autoincrement=True),
+        Column("baz", Integer),
+    )
+
+
 class FooAccessPattern(Protocol):
     @query(sql="select bar, baz from foo where bar = {bar}", load=one(Foo))
     async def getFoo(self, bar: int) -> Foo:
         ...
+
+    if alchemized:
+
+        @query(
+            sql=(fooTable.select().where(fooTable.c.bar == bindparam("bar"))),
+            load=one(Foo),
+        )
+        async def getFooAlchemized(self, bar: int) -> Foo:
+            ...
 
     @query(
         sql="select bar, baz from foo order by bar asc",
@@ -66,9 +94,27 @@ class FooAccessPattern(Protocol):
     def allFoos(self) -> AsyncIterable[Foo]:
         ...
 
+    if alchemized:
+
+        @query(
+            sql=(fooTable.select()),
+            load=many(Foo),
+        )
+        def allFoosAlchemized(self) -> AsyncIterable[Foo]:
+            ...
+
     @query(sql="select bar, baz from foo where bar = {bar}", load=maybe(Foo))
     async def maybeFoo(self, bar: int) -> Optional[Foo]:
         ...
+
+    if alchemized:
+
+        @query(
+            sql=(fooTable.select().where(fooTable.c.bar == bindparam("bar"))),
+            load=maybe(Foo),
+        )
+        async def maybeFooAlchemized(self, bar: int) -> Foo | None:
+            ...
 
     @query(sql="select bar, baz from foo where baz = {baz}", load=one(Foo))
     async def oneFooByBaz(self, baz: int) -> Foo:
@@ -170,6 +216,24 @@ class AccessTestCase(TestCase):
             result2 = await db.maybeFoo(1)
             result3 = [  # pragma: no branch
                 each async for each in db.allFoos()
+            ]
+        self.assertEqual(result, Foo(db, 1, 3))
+        self.assertEqual(result, result2)
+        self.assertEqual(result3, [Foo(db, 1, 3), Foo(db, 2, 4)])
+
+    @immediateTest()
+    async def test_happyPathAlchemized(self, pool: MemoryPool) -> None:
+        """
+        Test the same functionality as test_happyPath but with SQLAlchemy
+        queries.
+        """
+        async with transaction(pool.connectable) as c:
+            await schemaAndData(c)
+            db = accessFoo(c)
+            result = await db.getFooAlchemized(1)
+            result2 = await db.maybeFooAlchemized(1)
+            result3 = [  # pragma: no branch
+                each async for each in db.allFoosAlchemized()
             ]
         self.assertEqual(result, Foo(db, 1, 3))
         self.assertEqual(result, result2)

--- a/src/dbxs/test/test_access.py
+++ b/src/dbxs/test/test_access.py
@@ -165,6 +165,15 @@ class FooAccessPattern(Protocol):
         Create a new C{Foo} and return it.
         """
 
+    @query(
+        sql="select {repeat}, {repeat}",
+        load=one(lambda db, first, second: (first, second)),
+    )
+    async def repeatedArgument(self, repeat: str) -> tuple[str, str]:
+        """
+        Ensure a repeated argument is the same.
+        """
+
 
 class OtherAccessPattern(Protocol):
     @query(sql="select {value} + 1", load=one(lambda db, x: x))
@@ -254,6 +263,13 @@ class AccessTestCase(TestCase):
             self.assertEqual(result, "7")
             result = await db.echoValue()
             self.assertEqual(result, "3")
+
+    @immediateTest(styles=["qmark", "named", "numeric_dollar"])
+    async def test_repeatParams(self, pool: MemoryPool) -> None:
+        async with transaction(pool.connectable) as c:
+            db = accessFoo(c)
+            values = await db.repeatedArgument("test-value")
+            self.assertEqual(values, ("test-value", "test-value"))
 
     @immediateTest()
     async def test_wrongResultArity(self, pool: MemoryPool) -> None:

--- a/src/dbxs/test/test_access.py
+++ b/src/dbxs/test/test_access.py
@@ -303,6 +303,31 @@ class AccessTestCase(TestCase):
                 async def someMissing(self, bar: str) -> None:
                     ...
 
+    def test_argumentExhaustivenessAlchemized(self) -> None:
+        """
+        L{test_argumentExhaustiveness} but with SQLAlchemy bindparams rather
+        than string placeholders
+        """
+        with self.assertRaises(ParamMismatch) as pm:
+
+            class MissingBar(Protocol):
+                @statement(
+                    sql=fooTable.select().where(
+                        fooTable.c.bar == bindparam("bar")
+                    )
+                )
+                async def someUnused(self) -> None:
+                    ...
+
+        self.assertIn("bar", str(pm.exception))
+        self.assertIn("someUnused", str(pm.exception))
+        with self.assertRaises(ParamMismatch):
+
+            class DoesntUseBar(Protocol):
+                @statement(sql=fooTable.select())
+                async def someMissing(self, bar: str) -> None:
+                    ...
+
     @immediateTest()
     async def test_tooManyResults(self, pool: MemoryPool) -> None:
         """

--- a/src/dbxs/test/test_access.py
+++ b/src/dbxs/test/test_access.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import traceback
 from dataclasses import dataclass
 from typing import AsyncIterable, Optional
-from unittest import TestCase
+from unittest import TestCase, skipIf
 
 from .. import (
     ExtraneousMethods,
@@ -221,6 +221,7 @@ class AccessTestCase(TestCase):
         self.assertEqual(result, result2)
         self.assertEqual(result3, [Foo(db, 1, 3), Foo(db, 2, 4)])
 
+    @skipIf(not alchemized, "SQLAlchemy not installed")
     @immediateTest()
     async def test_happyPathAlchemized(self, pool: MemoryPool) -> None:
         """
@@ -303,6 +304,7 @@ class AccessTestCase(TestCase):
                 async def someMissing(self, bar: str) -> None:
                     ...
 
+    @skipIf(not alchemized, "SQLAlchemy not installed")
     def test_argumentExhaustivenessAlchemized(self) -> None:
         """
         L{test_argumentExhaustiveness} but with SQLAlchemy bindparams rather

--- a/src/dbxs/test/test_access.py
+++ b/src/dbxs/test/test_access.py
@@ -240,7 +240,8 @@ class AccessTestCase(TestCase):
         self.assertEqual(result, result2)
         self.assertEqual(result3, [Foo(db, 1, 3), Foo(db, 2, 4)])
 
-    @immediateTest()
+    # game branch coverage a little bit by selecting a non-qmark style
+    @immediateTest(styles=["named"])
     async def test_defaultParamValue(self, pool: MemoryPool) -> None:
         """
         Default parameters specified by the access Protocol are incorporated

--- a/src/dbxs/test/test_access.py
+++ b/src/dbxs/test/test_access.py
@@ -204,7 +204,7 @@ class AccessTestCase(TestCase):
     Tests for L{accessor} and its associated functions
     """
 
-    @immediateTest()
+    @immediateTest(styles=["qmark", "named", "numeric_dollar"])
     async def test_happyPath(self, pool: MemoryPool) -> None:
         """
         Declaring a protocol with a query and executing it
@@ -222,7 +222,7 @@ class AccessTestCase(TestCase):
         self.assertEqual(result3, [Foo(db, 1, 3), Foo(db, 2, 4)])
 
     @skipIf(not alchemized, "SQLAlchemy not installed")
-    @immediateTest()
+    @immediateTest(styles=["qmark", "named", "numeric_dollar"])
     async def test_happyPathAlchemized(self, pool: MemoryPool) -> None:
         """
         Test the same functionality as test_happyPath but with SQLAlchemy

--- a/src/dbxs/test/test_sync_adapter.py
+++ b/src/dbxs/test/test_sync_adapter.py
@@ -1,6 +1,7 @@
 """
 Tests for running synchronous DB-API drivers within threads.
 """
+
 from __future__ import annotations
 
 import sqlite3

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     coverage-py{38,39,310,311,py3}-tw{212,221,2310,trunk}
     coverage-py312-tw2310-postgresql
     coverage-py312-tw2310-mysql
+    coverage-py312-tw2310-sqlalchemy
     coverage_combine
     coverage_report
     docs, docs-linkcheck
@@ -24,6 +25,7 @@ deps =
     twtrunk: https://github.com/twisted/twisted/tarball/trunk#egg=Twisted
     postgres: -r requirements/postgres.txt
     mysql: -r requirements/mysql.txt
+    sqlalchemy: -r requirements/sqlalchemy.txt
 
     -r requirements/tox-pin-base.txt
     {test,coverage}: -r requirements/tox-tests.txt


### PR DESCRIPTION
Allow for specifying SQLAlchemy Core queries as `sql=` parameter rather than just strings.